### PR TITLE
Atualiza README

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,93 @@
+# PolyglotPiranha Python API
+
+This document describes the main classes and functions exposed by the
+`polyglot_piranha` Python package. It mirrors the Rust API used in the
+command-line interface.
+
+## execute_piranha
+
+```python
+from polyglot_piranha import execute_piranha, PiranhaArguments
+
+result = execute_piranha(PiranhaArguments(language="java", code_snippet="..."))
+```
+
+Executes Piranha with the provided arguments and returns a list of
+`PiranhaOutputSummary` objects representing the transformation applied to each
+file.
+
+## PiranhaArguments
+
+`PiranhaArguments` captures the configuration for running Piranha. Fields marked
+as optional use sensible defaults when omitted.
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `language` | `str` | Target language (e.g. `java`, `python`, `swift`) |
+| `paths_to_codebase` | `list[str]` | Paths to source files or directories |
+| `include` | `list[str]` | Glob patterns of files to include |
+| `exclude` | `list[str]` | Glob patterns of files to exclude |
+| `substitutions` | `dict[str, str]` | Values to instantiate rule variables |
+| `path_to_configurations` | `str` | Directory containing `rules.toml` and `edges.toml` |
+| `rule_graph` | `RuleGraph` | Custom rule graph built via the API |
+| `code_snippet` | `str` | In‑memory code to transform instead of files |
+| `dry_run` | `bool` | Disable in‑place rewrites |
+| `cleanup_comments` | `bool` | Remove comments related to deleted code |
+| `cleanup_comments_buffer` | `int` | Number of lines to search for comments |
+| `number_of_ancestors_in_parent_scope` | `int` | Ancestors to consider for `Parent` scope |
+| `delete_consecutive_new_lines` | `bool` | Collapse blank lines after edits |
+| `global_tag_prefix` | `str` | Prefix for generated global tags |
+| `delete_file_if_empty` | `bool` | Remove files that become empty |
+| `path_to_output` | `str` | Where to write the JSON summary |
+| `allow_dirty_ast` | `bool` | Allow parsing errors in input files |
+| `should_validate` | `bool` | Validate the rule graph before running |
+| `experiment_dyn` | `bool` | Internal feature flag |
+| `path_to_custom_builtin_rules` | `str` | Override built‑in cleanup rules |
+
+## Rule
+
+Represents a single match/replace rule.
+
+```python
+Rule(
+    name="replace_method",
+    query="cs :[x].isEnabled()",
+    replace_node="*",
+    replace="true",
+    is_seed_rule=True,
+)
+```
+
+`query` can be a tree-sitter query, a regex (prefix with `rgx`), or a concrete
+syntax template (prefix with `cs`).
+
+## Filter
+
+Filters restrict where a rule is applied.
+
+```python
+Filter(enclosing_node="cs class :[c] { :[body] }")
+```
+
+## OutgoingEdges and RuleGraph
+
+`OutgoingEdges` connect rules in a `RuleGraph`. The `scope` determines where the
+subsequent rules run (`Parent`, `Method`, `Class`, or `Global`).
+
+```python
+edge = OutgoingEdges("replace_method", to=["boolean_literal_cleanup"], scope="Parent")
+rg = RuleGraph(rules=[rule], edges=[edge])
+```
+
+## PiranhaOutputSummary
+
+The result produced by `execute_piranha` for each file.
+
+```python
+summary.path          # Path to the file
+summary.content       # Final content
+summary.matches       # Matches for match-only rules
+summary.rewrites      # List of edits performed
+```
+
+See `demo/` for runnable examples of these APIs.

--- a/POLYGLOT_README.md
+++ b/POLYGLOT_README.md
@@ -119,31 +119,29 @@ We believe this makes it easy to incorporate Piranha in *"pipelining"*.
 <h4> <code>execute_piranha</code></h4>
 
 ```python
-from polyglot_piranha import execute_piranha, PiranhaArguments
-
 piranha_arguments = PiranhaArguments(
-    path_to_codebase = "...",
-    path_to_configurations = "...",
-    language= "java",
-    substitutions = {},
-    dry_run = False, 
-    cleanup_comments = True
+    language="java",
+    paths_to_codebase=["..."],
+    path_to_configurations="...",
+    substitutions={},
+    dry_run=False,
+    cleanup_comments=True,
 )
 piranha_summary = execute_piranha(piranha_arguments)
 ```
-The API `execute_piranha` accepts a `PiranhaArguments`
-An object of PiranhaArguments can be instantiated with the following arguments:
+The API `execute_piranha` accepts a `PiranhaArguments` object.
+An instance of `PiranhaArguments` can be created with the following fields:
 
-- (*required*) `path_to_codebase` (`str`): Path to source code folder
-- (*required*) `path_to_configuration` (`str`) : A directory containing files named `rules.toml` and `edges.toml`
+- (*required*) `paths_to_codebase` (`list[str]`): Paths to the source files or directories
+- (*required*) `path_to_configurations` (`str`): Directory containing `rules.toml` and `edges.toml`
   * `rules.toml`: *piranha rules* expresses the specific AST patterns to match and __replacement patterns__ for these matches (in-place). These rules can also specify the pre-built language specific cleanups to trigger.
   * `edges.toml` : expresses the flow between the rules
-- (*required*) `language` (`str`) : Target language (`java`, `py`, `kt`, `swift`, `py`, `ts` and `tsx`)
+- (*required*) `language` (`str`): Target language (`java`, `kt`, `kotlin`, `go`, `python`, `swift`, `typescript`, `tsx`, `thrift`, `strings`, `scm`, `scala`, `ruby`, `yaml`, `yml`)
 - (*required*) `substitutions` (`dict`): Substitutions to instantiate the initial set of feature flag rules
 - (*optional*) `dry_run` (`bool`) : Disables in-place rewriting of code
 - (*optional*) `cleanup_comments` (`bool`) : Enables deletion of associated comments
 - (*optional*) `cleanup_comments_buffer` (`usize`): The number of lines to consider for cleaning up the comments
-- (*optional*) `number_of_ancestors_in_parent_scope` (`usize`): The number of ancestors considered when `PARENT` rules
+- (*optional*) `number_of_ancestors_in_parent_scope` (`usize`): Number of ancestors considered when applying rules with `Parent` scope
 - (*optional*) `delete_file_if_empty` (`bool`): User option that determines whether an empty file will be deleted
 - (*optional*) `delete_consecutive_new_lines` (`bool`) : Replaces consecutive `\n`s  with a single `\n`
 
@@ -467,7 +465,7 @@ replace_node = "binary_expression"
 replace = "true"
 ```
 
-Currently, Piranha picks up the language specific configurations from `src/cleanup_rule/<language>`.
+Currently, Piranha picks up the language specific configurations from `src/cleanup_rules/<language>`.
 
 
 <h5> Example </h5>

--- a/README.md
+++ b/README.md
@@ -1,38 +1,37 @@
 # PolyglotPiranha
 
-PolyglotPiranha is a lightweight code transformation toolset for automating large scale changes. At Uber, it is mostly used to clean up stale feature flags.
+PolyglotPiranha is a lightweight toolset for automating code transformations at scale. Uber primarily uses it to remove code associated with stale feature flags.
 
-We only support languages that are used at Uber. We likely won't be able to add new languages in this repo. There are a number of forks (see https://github.com/uber/piranha/forks for a full list) that may provide additional features.
-
+Only languages used at Uber are officially supported in this repository. Additional forks might offer support for other languages.
 
 ## Installation
 
-To install Polyglot Piranha, you can use it as a Python library or as a command-line tool.
+PolyglotPiranha can be used either as a Python library or via its command-line interface.
 
-### Python API
+### Python
 
-To install the Python API, run the following command:
+Install from PyPI:
 
 ```bash
 pip install polyglot-piranha
 ```
 
-### Command-line Interface
+### Command line
 
-To install the command-line interface, follow these steps:
+Download a platform specific binary from the [releases](https://github.com/uber/piranha/releases) page or build it from source:
 
-1. Install [Rust](https://www.rust-lang.org/tools/install)
-2. Clone the repository: `git clone https://github.com/uber/piranha.git`
-3. Navigate to the cloned directory: `cd piranha`
-4. Build the project: `cargo build --release` (or `cargo build --release --no-default-features` for macOS)
-5. The binary will be generated under `target/release`
+1. Install [Rust](https://www.rust-lang.org/tools/install).
+2. Clone the repository: `git clone https://github.com/uber/piranha.git`.
+3. Run `cargo build --release` (use `--no-default-features` on macOS).
+4. The binary will be located under `target/release`.
 
-## Example Usage
+## Example
+
+The snippet below shows how to apply a custom rewrite using the Python API.
 
 ```python
 from polyglot_piranha import execute_piranha, PiranhaArguments, Rule, RuleGraph, OutgoingEdges
 
-# Original code snippet
 code = """
 if (obj.isLocEnabled() || x > 0) {
     // do something
@@ -41,78 +40,56 @@ if (obj.isLocEnabled() || x > 0) {
 }
 """
 
-# Define the rule to replace the method call
-r1 = Rule(
+rule = Rule(
     name="replace_method",
-    query="cs :[x].isLocEnabled()", # cs indicates we are using concrete syntax
+    query="cs :[x].isLocEnabled()",  # 'cs' denotes concrete syntax
     replace_node="*",
     replace="true",
-    is_seed_rule=True
+    is_seed_rule=True,
 )
 
-# Define the edges for the rule graph. 
-# In this case, boolean_literal_cleanup is already defined for java [see src/cleanup_rules]
-edge = OutgoingEdges("replace_method", to=["boolean_literal_cleanup"], scope="parent")
+edge = OutgoingEdges("replace_method", to=["boolean_literal_cleanup"], scope="Parent")
 
-# Create Piranha arguments
-piranha_arguments = PiranhaArguments(
+args = PiranhaArguments(
     code_snippet=code,
     language="java",
-    rule_graph=RuleGraph(rules=[r1], edges=[edge])
+    rule_graph=RuleGraph(rules=[rule], edges=[edge]),
 )
 
-# Execute Piranha and print the transformed code
-piranha_summary = execute_piranha(piranha_arguments)
-print(piranha_summary[0].content)
+result = execute_piranha(args)
+print(result[0].content)
 ```
 
+For more examples and details about the DSL, see [POLYGLOT_README.md](POLYGLOT_README.md).
+Complete API documentation is available in [API.md](API.md).
 
-## Documentation
+## Feature flags
 
-For more examples and explanations of the toolset, please check our demos and extended [POLYGLOT_README.md](POLYGLOT_README.md) file.
+Feature flags help with gradual rollouts or experiments. Once a flag is obsolete the related code should be removed to avoid clutter and potential bugs. PolyglotPiranha can automate this process. The tool takes the flag name, its expected behaviour and a list of APIs interacting with that flag to perform the cleanup.
 
+PolyglotPiranha (since May 2022) unifies support for multiple languages and feature flag APIs. Legacy language-specific implementations are available under [this tag](https://github.com/uber/piranha/releases/tag/last-version-having-legacy-piranha).
 
-## Feature Flags
+Additional resources:
 
-
-Feature flags are commonly used to enable gradual rollout or experiment with new features. In a few cases, even after the purpose of the flag is accomplished, the code pertaining to the feature flag is not removed. We refer to such flags as stale flags. The presence of code pertaining to stale flags can have the following drawbacks: 
-- Unnecessary code clutter increases the overall complexity w.r.t maintenance resulting in reduced developer productivity 
-- The flags can interfere with other experimental flags (e.g., due to nesting under a flag that is always false)
-- Presence of unused code in the source as well as the binary 
-- Stale flags can also cause bugs 
-
-PolyglotPiranha is a tool that can automatically refactor code related to stale flags. At a higher level, the input to the tool is the name of the flag and the expected behavior, after specifying a list of APIs related to flags in a properties file. Piranha will use these inputs to automatically refactor the code according to the expected behavior.
-
-PolyglotPiranha (as of May 2022) is a common refactoring tool to support multiple languages and feature flag APIs.
-For legacy language-specific implementations please check following [tag](https://github.com/uber/piranha/releases/tag/last-version-having-legacy-piranha).
-
-
-
-A few additional links on Piranha: 
-
-- Research paper published at [PLDI 2024](https://dl.acm.org/doi/10.1145/3656429) on PolyglotPiranha.
-- A technical [report](report.pdf) detailing our experiences with using Piranha at Uber.
-- A [blogpost](https://eng.uber.com/piranha/) presenting more information on Piranha. 
-- 6 minute [video](https://www.youtube.com/watch?v=V5XirDs6LX8&feature=emb_logo) overview of Piranha.
+- Research paper at [PLDI 2024](https://dl.acm.org/doi/10.1145/3656429)
+- [Technical report](report.pdf) on Piranha at Uber
+- [Blog post](https://eng.uber.com/piranha/)
+- [6 minute video](https://www.youtube.com/watch?v=V5XirDs6LX8&feature=emb_logo)
 
 ## Support
 
-If you have any questions on how to use Piranha or find any bugs, please [open a GitHub issue](https://github.com/uber/piranha/issues).
+Questions or bugs? [Open a GitHub issue](https://github.com/uber/piranha/issues).
 
-## Piranha Development
+## Piranha development
 
-Piranha uses several grammar repositories with custom patches to support the transformations. While
-these patches are being upstreamed, there may be discrepancies between the grammars in this 
-repository and the upstream grammars. Therefore, we have built a custom tree-sitter playground
-that can be used to test the grammars and queries for easier development:
+We maintain custom patches for several tree-sitter grammars. While these patches are upstreamed, discrepancies may exist. A playground for testing grammars and queries is available at:
 
 https://uber.github.io/piranha/tree-sitter-playground/
 
 ## License
-Piranha is licensed under the Apache 2.0 license.  See the LICENSE file for more information.
+
+Piranha is licensed under the Apache 2.0 license. See the LICENSE file for details.
 
 ## Note
 
-This is not an official Uber product, and provided as is.
-
-
+This is not an official Uber product and is provided as is.


### PR DESCRIPTION
## Summary
- improve introduction and installation instructions
- update Python API example and docs
- fix outdated explanations about feature flags
- clarify arguments in POLYGLOT_README
- add API reference for Python interfaces

## Testing
- `pip install .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887dc16277c8332a5a311bd22ef593f