### PR TITLE
Add TypeScript cleanup rules

### DIFF
--- a/crates/core/src/cleanup_rules/typescript/edges.toml
+++ b/crates/core/src/cleanup_rules/typescript/edges.toml
@@ -1,0 +1,9 @@
+[[edges]]
+scope = "Parent"
+from = "simplify_if_statement_dynamic_true"
+to = ["remove_unnecessary_nested_block"]
+
+[[edges]]
+scope = "Parent"
+from = "simplify_if_statement_dynamic_false"
+to = ["remove_unnecessary_nested_block"]

--- a/crates/core/src/cleanup_rules/typescript/rules.toml
+++ b/crates/core/src/cleanup_rules/typescript/rules.toml
@@ -1,0 +1,53 @@
+[[rules]]
+name = "simplify_if_statement_dynamic_true"
+query = """
+(
+  (if_statement
+    condition: (parenthesized_expression (_) @cond)
+    consequence: (_) @consequence
+    alternative: (_) @alternative
+  ) @if_statement
+  (#eq? @cond "@flag_condition")
+)
+"""
+replace = "@consequence"
+replace_node = "if_statement"
+holes = ["flag_condition"]
+groups = ["if_cleanup"]
+is_seed_rule = true
+
+[[rules]]
+name = "simplify_if_statement_dynamic_false"
+query = """
+(
+  (if_statement
+    condition: (parenthesized_expression (_) @cond)
+    consequence: (_) @consequence
+  ) @if_statement
+  (#eq? @cond "@flag_condition")
+)
+"""
+replace = "@consequence"
+replace_node = "if_statement"
+holes = ["flag_condition"]
+groups = ["if_cleanup"]
+is_seed_rule = true
+
+[[rules]]
+name = "remove_unnecessary_nested_block"
+query = """
+(
+  (statement_block
+    (statement_list
+      (_)* @pre
+      (statement_block
+        (statement_list) @nested.statements
+      ) @nested.block
+      (_)* @post
+    ) @outer.stmt_list
+  ) @outer.block
+)
+"""
+replace = "@nested.statements"
+replace_node = "nested.block"
+is_seed_rule = false

--- a/crates/core/src/cleanup_rules/typescript/scope_config.toml
+++ b/crates/core/src/cleanup_rules/typescript/scope_config.toml
@@ -1,0 +1,33 @@
+[[scopes]]
+name = "File"
+[[scopes.rules]]
+enclosing_node = """
+(source_file) @source_file
+"""
+scope = """(source_file) @sf"""
+
+[[scopes]]
+name = "Function-Method"
+[[scopes.rules]]
+enclosing_node = """
+(
+    (
+        [
+            (function_declaration name: (_) @n parameters: (formal_parameters) @pl)
+            (method_definition name: (_) @n parameters: (formal_parameters) @pl)
+        ]
+    ) @f_decl1
+)
+"""
+scope = """
+(
+    (
+        [
+            (function_declaration name: (_) @fn parameters: (formal_parameters) @paramlist)
+            (method_definition name: (_) @fn parameters: (formal_parameters) @paramlist)
+        ]
+    ) @f_decl2
+    (#eq? @fn "@n")
+    (#eq? @paramlist "@pl")
+)
+"""

--- a/crates/core/test-resources/typescript/if_cleanup/expected/Sample.jsx
+++ b/crates/core/test-resources/typescript/if_cleanup/expected/Sample.jsx
@@ -1,0 +1,5 @@
+if (source.ff) {
+  console.log("true");
+} else {
+  console.log("false");
+}

--- a/crates/core/test-resources/typescript/if_cleanup/expected/Sample.ts
+++ b/crates/core/test-resources/typescript/if_cleanup/expected/Sample.ts
@@ -1,0 +1,3 @@
+{
+  console.log("true");
+}

--- a/crates/core/test-resources/typescript/if_cleanup/expected/Sample.tsx
+++ b/crates/core/test-resources/typescript/if_cleanup/expected/Sample.tsx
@@ -1,0 +1,3 @@
+{
+  console.log("true");
+}

--- a/crates/core/test-resources/typescript/if_cleanup/input/Sample.jsx
+++ b/crates/core/test-resources/typescript/if_cleanup/input/Sample.jsx
@@ -1,0 +1,5 @@
+if (source.ff) {
+  console.log("true");
+} else {
+  console.log("false");
+}

--- a/crates/core/test-resources/typescript/if_cleanup/input/Sample.ts
+++ b/crates/core/test-resources/typescript/if_cleanup/input/Sample.ts
@@ -1,0 +1,5 @@
+if (source.ff) {
+  console.log("true");
+} else {
+  console.log("false");
+}

--- a/crates/core/test-resources/typescript/if_cleanup/input/Sample.tsx
+++ b/crates/core/test-resources/typescript/if_cleanup/input/Sample.tsx
@@ -1,0 +1,5 @@
+if (source.ff) {
+  console.log("true");
+} else {
+  console.log("false");
+}

--- a/tests/test_piranha.py
+++ b/tests/test_piranha.py
@@ -378,3 +378,45 @@ def test_kotlin_boolean_simplification():
         }
         return true
         }"""
+
+def test_typescript_if_cleanup():
+    rule = Rule(
+        name="cleanup_flag_true",
+        query="""
+        (
+            (if_statement
+                condition: (parenthesized_expression (_) @cond)
+                consequence: (_) @cons
+                alternative: (_) @alt
+            ) @if_stmt
+            (#eq? @cond "@flag_condition")
+        )""",
+        replace="@cons",
+        replace_node="if_stmt",
+        holes={"flag_condition"},
+        is_seed_rule=True,
+    )
+    args_ts = PiranhaArguments(
+        language="typescript",
+        paths_to_codebase=[
+            "crates/core/test-resources/typescript/if_cleanup/input/Sample.ts",
+        ],
+        substitutions={"flag_condition": "source.ff"},
+        rule_graph=RuleGraph(rules=[rule], edges=[]),
+        dry_run=True,
+    )
+    args_tsx = PiranhaArguments(
+        language="tsx",
+        paths_to_codebase=[
+            "crates/core/test-resources/typescript/if_cleanup/input/Sample.tsx",
+            "crates/core/test-resources/typescript/if_cleanup/input/Sample.jsx",
+        ],
+        substitutions={"flag_condition": "source.ff"},
+        rule_graph=RuleGraph(rules=[rule], edges=[]),
+        dry_run=True,
+    )
+    output_summaries = execute_piranha(args_ts) + execute_piranha(args_tsx)
+    assert len(output_summaries) == 2
+    assert is_as_expected(
+        "crates/core/test-resources/typescript/if_cleanup", output_summaries
+    )


### PR DESCRIPTION
## Summary
- add TypeScript cleanup rules mirroring Java behaviour
- connect rules via edges and scopes
- test TypeScript refactoring on `.ts` and `.tsx`

## Testing
- `pytest -q tests/test_piranha.py::test_typescript_if_cleanup -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887e9e2a90c833289ab825e00652882